### PR TITLE
Apply patch from PR to modify repo content

### DIFF
--- a/recipe/PR_379.diff
+++ b/recipe/PR_379.diff
@@ -1,0 +1,329 @@
+diff --git README.rst README.rst
+index 5316a22..395ea57 100644
+--- README.rst
++++ README.rst
+@@ -75,8 +75,6 @@ A lot of things including the following URLs, and every new things published by
+ * ``/notifications/threads/:id/subscription`` (DELETE)
+ * ``/notifications/threads/:id/subscription`` (GET)
+ * ``/notifications/threads/:id/subscription`` (PUT)
+-* ``/repos/:owner/:repo/contents/:path`` (DELETE)
+-* ``/repos/:owner/:repo/contents/:path`` (PUT)
+ * ``/repos/:owner/:repo/notifications`` (GET)
+ * ``/repos/:owner/:repo/notifications`` (PUT)
+ * ``/repos/:owner/:repo/releases/:id/assets`` (GET)
+diff --git github/Repository.py github/Repository.py
+index be76516..814982b 100644
+--- github/Repository.py
++++ github/Repository.py
+@@ -29,9 +29,10 @@
+ # along with PyGithub. If not, see <http://www.gnu.org/licenses/>.             #
+ #                                                                              #
+ # ##############################################################################
+-
++import sys
+ import urllib
+ import datetime
++from base64 import b64encode
+ 
+ import github.GithubObject
+ import github.PaginatedList
+@@ -70,6 +71,8 @@
+ import github.StatsPunchCard
+ import github.Stargazer
+ 
++atLeastPython26 = sys.hexversion >= 0x02060000
++atLeastPython3 = sys.hexversion >= 0x03000000
+ 
+ class Repository(github.GithubObject.CompletableGithubObject):
+     """
+@@ -1216,6 +1219,152 @@ def get_file_contents(self, path, ref=github.GithubObject.NotSet):
+         )
+         return github.ContentFile.ContentFile(self._requester, headers, data, completed=True)
+ 
++    def create_file(self, path, message, content,
++                    branch=github.GithubObject.NotSet,
++                    committer=github.GithubObject.NotSet,
++                    author=github.GithubObject.NotSet):
++        """Create a file in this repository.
++        :calls: `PUT /repos/:owner/:repo/contents/:path <http://developer.github.com/v3/repos/contents#create-a-file>`_
++        :param path: string, (required), path of the file in the repository
++        :param message: string, (required), commit message
++        :param content: string, (required), the actual data in the file
++        :param branch: string, (optional), branch to create the commit on. Defaults to the default branch of the repository
++        :param committer: dict, (optional), if no information is given the authenticated user's information will be used. You must specify both a name and email.
++        :param author: dict, (optional), if omitted this will be filled in with committer information. If passed, you must specify both a name and email.
++        :rtype: {
++            'content': :class:`ContentFile <github.ContentFile.ContentFile>`:,
++            'commit': :class:`Commit <github.Commit.Commit>`}
++        """
++        assert isinstance(path, (str, unicode)),                   \
++            'path must be str/unicode object'
++        assert isinstance(message, (str, unicode)),                \
++            'message must be str/unicode object'
++        assert isinstance(content, (str, unicode)),                \
++            'content must be a str/unicode object'
++        assert branch is github.GithubObject.NotSet                \
++            or isinstance(branch, (str, unicode)),                 \
++            'branch must be a str/unicode object'
++        assert author is github.GithubObject.NotSet                \
++            or isinstance(author, github.InputGitAuthor),          \
++            'author must be a github.InputGitAuthor object'
++        assert committer is github.GithubObject.NotSet             \
++            or isinstance(committer, github.InputGitAuthor),       \
++            'committer must be a github.InputGitAuthor object'
++
++        if atLeastPython3:
++            content = b64encode(content.encode('utf-8')).decode('utf-8')
++        else:
++            content = b64encode(content)
++        put_parameters = {'message': message, 'content': content}
++
++        if branch is not github.GithubObject.NotSet:
++            put_parameters['branch'] = branch
++        if author is not github.GithubObject.NotSet:
++            put_parameters["author"] = author._identity
++        if committer is not github.GithubObject.NotSet:
++            put_parameters["committer"] = committer._identity
++
++        headers, data = self._requester.requestJsonAndCheck(
++            "PUT",
++            self.url + "/contents" + path,
++            input=put_parameters
++        )
++
++        return {'content': github.ContentFile.ContentFile(self._requester, headers, data, completed=True),
++                'commit': github.Commit.Commit(self._requester, headers, data, completed=True)}
++
++    def update_file(self, path, message, content, sha,
++                    branch=github.GithubObject.NotSet,
++                    committer=github.GithubObject.NotSet,
++                    author=github.GithubObject.NotSet):
++        """This method updates a file in a repository
++        :calls: `PUT /repos/:owner/:repo/contents/:path <http://developer.github.com/v3/repos/contents#update-a-file>`_
++        :param path: string, Required. The content path.
++        :param message: string, Required. The commit message.
++        :param content: string, Required. The updated file content, Base64 encoded.
++        :param sha: string, Required. The blob SHA of the file being replaced.
++        :param branch: string. The branch name. Default: the repository’s default branch (usually master)
++        :rtype: {
++            'content': :class:`ContentFile <github.ContentFile.ContentFile>`:,
++            'commit': :class:`Commit <github.Commit.Commit>`}
++        """
++        assert isinstance(path, (str, unicode)),                   \
++            'path must be str/unicode object'
++        assert isinstance(message, (str, unicode)),                \
++            'message must be str/unicode object'
++        assert isinstance(content, (str, unicode)),                \
++            'content must be a str/unicode object'
++        assert isinstance(sha, (str, unicode)),                    \
++            'sha must be a str/unicode object'
++        assert branch is github.GithubObject.NotSet                \
++            or isinstance(branch, (str, unicode)),                 \
++            'branch must be a str/unicode object'
++        assert author is github.GithubObject.NotSet                \
++            or isinstance(author, github.InputGitAuthor),          \
++            'author must be a github.InputGitAuthor object'
++        assert committer is github.GithubObject.NotSet             \
++            or isinstance(committer, github.InputGitAuthor),       \
++            'committer must be a github.InputGitAuthor object'
++
++        if atLeastPython3:
++            content = b64encode(content.encode('utf-8')).decode('utf-8')
++        else:
++            content = b64encode(content)
++
++        put_parameters = {'message': message, 'content': content,
++                          'sha': sha}
++
++        if branch is not github.GithubObject.NotSet:
++            put_parameters['branch'] = branch
++        if author is not github.GithubObject.NotSet:
++            put_parameters["author"] = author._identity
++        if committer is not github.GithubObject.NotSet:
++            put_parameters["committer"] = committer._identity
++
++        headers, data = self._requester.requestJsonAndCheck(
++            "PUT",
++            self.url + "/contents" + path,
++            input=put_parameters
++        )
++
++        return {'commit': github.Commit.Commit(self._requester, headers, data, completed=True),
++                'content': github.ContentFile.ContentFile(self._requester, headers, data, completed=True)}
++
++    def delete_file(self, path, message, sha,
++                    branch=github.GithubObject.NotSet):
++        """This method delete a file in a repository
++        :calls: `DELETE /repos/:owner/:repo/contents/:path <https://developer.github.com/v3/repos/contents/#delete-a-file>`_
++        :param path: string, Required. The content path.
++        :param message: string, Required. The commit message.
++        :param sha: string, Required. The blob SHA of the file being replaced.
++        :param branch: string. The branch name. Default: the repository’s default branch (usually master)
++        :rtype: {
++            'content': :class:`null <github.GithubObject.NotSet>`:,
++            'commit': :class:`Commit <github.Commit.Commit>`}
++        """
++        assert isinstance(path, (str, unicode)),                   \
++            'path must be str/unicode object'
++        assert isinstance(message, (str, unicode)),                \
++            'message must be str/unicode object'
++        assert isinstance(sha, (str, unicode)),                    \
++            'sha must be a str/unicode object'
++        assert branch is github.GithubObject.NotSet                \
++            or isinstance(branch, (str, unicode)),                 \
++            'branch must be a str/unicode object'
++
++        url_parameters = {'message': message, 'sha': sha}
++        if branch is not github.GithubObject.NotSet:
++            url_parameters['branch'] = branch
++
++        headers, data = self._requester.requestJsonAndCheck(
++            "DELETE",
++            self.url + "/contents" + path,
++            input=url_parameters
++        )
++
++        return {'commit': github.Commit.Commit(self._requester, headers, data, completed=True),
++                'content': github.GithubObject.NotSet}
++
+     def get_dir_contents(self, path, ref=github.GithubObject.NotSet):
+         """
+         :calls: `GET /repos/:owner/:repo/contents/:path <http://developer.github.com/v3/repos/contents>`_
+diff --git github/tests/ReplayData/Repository.testCreateFile.txt github/tests/ReplayData/Repository.testCreateFile.txt
+new file mode 100644
+index 0000000..6015d67
+--- /dev/null
++++ github/tests/ReplayData/Repository.testCreateFile.txt
+@@ -0,0 +1,10 @@
++https
++PUT
++api.github.com
++None
++/repos/jacquev6/PyGithub/contents/doc/testCreateUpdateDeleteFile.md
++{'Content-Type': 'application/json', 'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}
++{"author": {"date": "2016-01-15T16:13:30+12:00", "email": "enix223@163.com", "name": "Enix Yu"}, "branch": "master", "committer": {"date": "2016-01-15T16:13:30+12:00", "email": "enix223@163.com", "name": "Enix Yu"}, "content": "SGVsbG8gd29ybGQ=", "message": "Create file for testCreateFile"}
++201
++[('status', '201 Created'), ('x-ratelimit-remaining', '4997'), ('content-length', '16'), ('server', 'nginx/1.0.13'), ('connection', 'keep-alive'), ('x-ratelimit-limit', '5000'), ('etag', '"f5cc2fa3ba4de95ac0eb8c2ca47350c0"'), ('date', 'Fri, 11 May 2012 11:43:09 GMT'), ('content-type', 'application/json; charset=utf-8'), ('location', 'https://api.github.com/repos/jacquev6/PyGithub/contents/doc/testCreateUpdateDeleteFile.md')]
++{"content": {"name": "hello.txt", "url": "https://api.github.com/repos/PyGithub/contents/doc/testCreateUpdateDeleteFile.md", "html_url": "https://github.com/PyGithub/doc/testCreateUpdateDeleteFile.md", "download_url": "https://raw.githubusercontent.com/PyGithub/doc/testCreateUpdateDeleteFile.md", "sha": "95b966ae1c166bd92f8ae7d1c313e738c731dfc3", "_links": {"self": "https://api.github.com/repos/PyGithub/contents/doc/testCreateUpdateDeleteFile.md", "git": "https://api.github.com/repos/PyGithub/git/blobs/95b966ae1c166bd92f8ae7d1c313e738c731dfc3", "html": "https://github.com/jacquev6/PyGithub/blob/master/doc/testCreateUpdateDeleteFile.md"}, "git_url": "https://api.github.com/repos/jacquev6/PyGithub/git/blobs/95b966ae1c166bd92f8ae7d1c313e738c731dfc3", "path": "doc/testCreateUpdateDeleteFile.md", "type": "file", "size": 9}, "commit": {"committer": {"date": "2014-11-07T22:01:45Z", "name": "Enix Yu", "email": "enix223@gmail.com"}, "author": {"date": "2016-01-15T16:13:30+12:00", "name": "Enix Yu", "email": "enix223@gmail.com"}, "url": "https://api.github.com/repos/jacquev6/PyGithub/git/commits/7638417db6d59f3c431d3e1f261cc637155684cd", "tree": {"url": "https://api.github.com/repos/jacquev6/PyGithub/git/trees/691272480426f78a0138979dd3ce63b77f706feb", "sha": "691272480426f78a0138979dd3ce63b77f706feb"}, "html_url": "https://github.com/jacquev6/PyGithub/git/commit/7638417db6d59f3c431d3e1f261cc637155684cd", "sha": "7638417db6d59f3c431d3e1f261cc637155684cd", "parents": [{"url": "https://api.github.com/repos/jacquev6/PyGithub/git/commits/1acc419d4d6a9ce985db7be48c6349a0475975b5", "sha": "1acc419d4d6a9ce985db7be48c6349a0475975b5", "html_url": "https://github.com/jacquev6/PyGithub/git/commit/1acc419d4d6a9ce985db7be48c6349a0475975b5"}], "Create file for testCreateFile"}}
+\ No newline at end of file
+diff --git github/tests/ReplayData/Repository.testDeleteFile.txt github/tests/ReplayData/Repository.testDeleteFile.txt
+new file mode 100644
+index 0000000..e977db6
+--- /dev/null
++++ github/tests/ReplayData/Repository.testDeleteFile.txt
+@@ -0,0 +1,21 @@
++https
++GET
++api.github.com
++None
++/repos/jacquev6/PyGithub/contents/doc/testCreateUpdateDeleteFile.md
++{'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}
++null
++200
++[('status', '200 OK'), ('content-length', '16'), ('x-github-media-type', 'github.beta; format=json'), ('x-content-type-options', 'nosniff'), ('x-ratelimit-limit', '5000'), ('vary', 'Accept, Authorization, Cookie'), ('x-ratelimit-remaining', '4997'), ('server', 'nginx/1.0.13'), ('last-modified', 'Wed, 05 Sep 2012 17:54:40 GMT'), ('connection', 'keep-alive'), ('etag', '"71786feb5f476112c5a8aa894ee7ca6c"'), ('cache-control', 'private, s-maxage=60, max-age=60'), ('date', 'Sat, 08 Sep 2012 10:43:48 GMT'), ('content-type', 'application/json; charset=utf-8')]
++{"type":"file","sha":"5628799a7d517a4aaa0c1a7004d07569cd154df0","path":"doc/testCreateUpdateDeleteFile.md","encoding":"base64","_links":{"self":"https://api.github.com/repos/jacquev6/PyGithub/contents/doc/testCreateUpdateDeleteFile.md","html":"https://github.com/jacquev6/PyGithub/blob/master/doc/testCreateUpdateDeleteFile.md","git":"https://api.github.com/repos/jacquev6/PyGithub/git/blobs/5628799a7d517a4aaa0c1a7004d07569cd154df0"},"content":"SGVsbG8gd29ybGQ=","size":16,"name":"doc/testCreateUpdateDeleteFile.md"}
++
++https
++DELETE
++api.github.com
++None
++/repos/jacquev6/PyGithub/contents/doc/testCreateUpdateDeleteFile.md
++{'Content-Type': 'application/json', 'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}
++{"branch": "master", "message": "Delete file for testDeleteFile", "sha": "5628799a7d517a4aaa0c1a7004d07569cd154df0"}
++200
++[('status', '200 OK'), ('content-length', '16'), ('x-github-media-type', 'github.beta; format=json'), ('x-content-type-options', 'nosniff'), ('x-ratelimit-limit', '5000'), ('vary', 'Accept, Authorization, Cookie'), ('x-ratelimit-remaining', '4997'), ('server', 'nginx/1.0.13'), ('last-modified', 'Wed, 05 Sep 2012 17:54:40 GMT'), ('connection', 'keep-alive'), ('etag', '"71786feb5f476112c5a8aa894ee7ca6c"'), ('cache-control', 'private, s-maxage=60, max-age=60'), ('date', 'Sat, 08 Sep 2012 10:43:48 GMT'), ('content-type', 'application/json; charset=utf-8')]
++{"content": None, "commit": {"committer": {"date": "2014-11-07T22:01:45Z", "name": "Scott Chacon", "email": "schacon@gmail.com"}, "author": {"date": "2014-11-07T22:01:45Z", "name": "Scott Chacon", "email": "schacon@gmail.com"}, "url": "https://api.github.com/repos/jacquev6/PyGithub/git/commits/7638417db6d59f3c431d3e1f261cc637155684cd", "tree": {"url": "https://api.github.com/repos/jacquev6/PyGithub/git/trees/691272480426f78a0138979dd3ce63b77f706feb", "sha": "691272480426f78a0138979dd3ce63b77f706feb"}, "html_url": "https://github.com/jacquev6/PyGithub/git/commit/7638417db6d59f3c431d3e1f261cc637155684cd", "sha": "7638417db6d59f3c431d3e1f261cc637155684cd", "parents": [{"url": "https://api.github.com/repos/jacquev6/PyGithub/git/commits/1acc419d4d6a9ce985db7be48c6349a0475975b5", "sha": "1acc419d4d6a9ce985db7be48c6349a0475975b5", "html_url": "https://github.com/jacquev6/PyGithub/git/commit/1acc419d4d6a9ce985db7be48c6349a0475975b5"}], "message": "Delete file for testDeleteFile"}}
+diff --git github/tests/ReplayData/Repository.testGetContents.txt github/tests/ReplayData/Repository.testGetContents.txt
+index c8201fb..24662a8 100644
+--- github/tests/ReplayData/Repository.testGetContents.txt
++++ github/tests/ReplayData/Repository.testGetContents.txt
+@@ -13,7 +13,7 @@ https
+ GET
+ api.github.com
+ None
+-/repos/jacquev6/PyGithub/contentsdoc/ReferenceOfClasses.md
++/repos/jacquev6/PyGithub/contents/doc/ReferenceOfClasses.md
+ {'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}
+ null
+ 200
+diff --git github/tests/ReplayData/Repository.testGetContentsWithRef.txt github/tests/ReplayData/Repository.testGetContentsWithRef.txt
+index 882d26f..ce33693 100644
+--- github/tests/ReplayData/Repository.testGetContentsWithRef.txt
++++ github/tests/ReplayData/Repository.testGetContentsWithRef.txt
+@@ -13,7 +13,7 @@ https
+ GET
+ api.github.com
+ None
+-/repos/jacquev6/PyGithub/contentsdoc/ReferenceOfClasses.md?ref=refs%2Fheads%2Ftopic%2FExperimentOnDocumentation
++/repos/jacquev6/PyGithub/contents/doc/ReferenceOfClasses.md?ref=refs%2Fheads%2Ftopic%2FExperimentOnDocumentation
+ {'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}
+ null
+ 200
+diff --git github/tests/ReplayData/Repository.testUpdateFile.txt github/tests/ReplayData/Repository.testUpdateFile.txt
+new file mode 100644
+index 0000000..81fb486
+--- /dev/null
++++ github/tests/ReplayData/Repository.testUpdateFile.txt
+@@ -0,0 +1,21 @@
++https
++GET
++api.github.com
++None
++/repos/jacquev6/PyGithub/contents/doc/testCreateUpdateDeleteFile.md
++{'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}
++null
++200
++[('status', '200 OK'), ('content-length', '16'), ('x-github-media-type', 'github.beta; format=json'), ('x-content-type-options', 'nosniff'), ('x-ratelimit-limit', '5000'), ('vary', 'Accept, Authorization, Cookie'), ('x-ratelimit-remaining', '4997'), ('server', 'nginx/1.0.13'), ('last-modified', 'Wed, 05 Sep 2012 17:54:40 GMT'), ('connection', 'keep-alive'), ('etag', '"71786feb5f476112c5a8aa894ee7ca6c"'), ('cache-control', 'private, s-maxage=60, max-age=60'), ('date', 'Sat, 08 Sep 2012 10:43:48 GMT'), ('content-type', 'application/json; charset=utf-8')]
++{"type":"file","sha":"5628799a7d517a4aaa0c1a7004d07569cd154df0","path":"doc/testCreateUpdateDeleteFile.md","encoding":"base64","_links":{"self":"https://api.github.com/repos/jacquev6/PyGithub/contents/doc/testCreateUpdateDeleteFile.md","html":"https://github.com/jacquev6/PyGithub/blob/master/doc/testCreateUpdateDeleteFile.md","git":"https://api.github.com/repos/jacquev6/PyGithub/git/blobs/5628799a7d517a4aaa0c1a7004d07569cd154df0"},"content":"SGVsbG8gd29ybGQ=","size":16,"name":"doc/testCreateUpdateDeleteFile.md"}
++
++https
++PUT
++api.github.com
++None
++/repos/jacquev6/PyGithub/contents/doc/testCreateUpdateDeleteFile.md
++{'Content-Type': 'application/json', 'Authorization': 'Basic login_and_password_removed', 'User-Agent': 'PyGithub/Python'}
++{"author": {"date": "2016-01-15T16:13:30+12:00", "email": "enix223@163.com", "name": "Enix Yu"}, "branch": "master", "committer": {"date": "2016-01-15T16:13:30+12:00", "email": "enix223@163.com", "name": "Enix Yu"}, "content": "SGVsbG8gV29ybGQ=", "message": "Update file for testUpdateFile", "sha": "5628799a7d517a4aaa0c1a7004d07569cd154df0"}
++200
++[('status', '200 OK'), ('content-length', '16'), ('x-github-media-type', 'github.beta; format=json'), ('x-content-type-options', 'nosniff'), ('x-ratelimit-limit', '5000'), ('vary', 'Accept, Authorization, Cookie'), ('x-ratelimit-remaining', '4997'), ('server', 'nginx/1.0.13'), ('last-modified', 'Wed, 05 Sep 2012 17:54:40 GMT'), ('connection', 'keep-alive'), ('etag', '"71786feb5f476112c5a8aa894ee7ca6c"'), ('cache-control', 'private, s-maxage=60, max-age=60'), ('date', 'Sat, 08 Sep 2012 10:43:48 GMT'), ('content-type', 'application/json; charset=utf-8')]
++{"content": {"name": "testCreateUpdateDeleteFile.md", "url": "https://api.github.com/repos/jacquev6/PyGithub/contents/doc/testCreateUpdateDeleteFile.md", "html_url": "https://github.com/jacquev6/PyGithub/blob/master/doc/testCreateUpdateDeleteFile.md", "download_url": "https://raw.githubusercontent.com/jacquev6/PyGithub/master/doc/testCreateUpdateDeleteFile.md", "sha": "95b966ae1c166bd92f8ae7d1c313e738c731dfc3", "_links": {"self": "https://api.github.com/repos/jacquev6/PyGithub/contents/doc/testCreateUpdateDeleteFile.md", "git": "https://api.github.com/repos/jacquev6/PyGithub/git/blobs/95b966ae1c166bd92f8ae7d1c313e738c731dfc3", "html": "https://github.com/jacquev6/PyGithub/blob/master/doc/testCreateUpdateDeleteFile.md"}, "git_url": "https://api.github.com/repos/jacquev6/PyGithub/git/blobs/95b966ae1c166bd92f8ae7d1c313e738c731dfc3", "path": "doc/testCreateUpdateDeleteFile.md", "type": "file", "size": 9}, "commit": {"committer": {"date": "2016-01-15T16:13:30+12:00", "name": "Enix Yu", "email": "enix223@gmail.com"}, "author": {"date": "2016-01-15T16:13:30+12:00", "name": "Enix Yu", "email": "enix223@gmail.com"}, "url": "https://api.github.com/repos/jacquev6/PyGithub/git/commits/7638417db6d59f3c431d3e1f261cc637155684cd", "tree": {"url": "https://api.github.com/repos/jacquev6/PyGithub/git/trees/691272480426f78a0138979dd3ce63b77f706feb", "sha": "691272480426f78a0138979dd3ce63b77f706feb"}, "html_url": "https://github.com/jacquev6/PyGithub/git/commit/7638417db6d59f3c431d3e1f261cc637155684cd", "sha": "7638417db6d59f3c431d3e1f261cc637155684cd", "parents": [{"url": "https://api.github.com/repos/jacquev6/PyGithub/git/commits/1acc419d4d6a9ce985db7be48c6349a0475975b5", "sha": "1acc419d4d6a9ce985db7be48c6349a0475975b5", "html_url": "https://github.com/jacquev6/PyGithub/git/commit/1acc419d4d6a9ce985db7be48c6349a0475975b5"}], "message": "my commit message"}}
+\ No newline at end of file
+diff --git github/tests/Repository.py github/tests/Repository.py
+index a2d9bb7..1c3752a 100644
+--- github/tests/Repository.py
++++ github/tests/Repository.py
+@@ -406,11 +406,33 @@ def testAssignees(self):
+ 
+     def testGetContents(self):
+         self.assertEqual(len(self.repo.get_readme().content), 10212)
+-        self.assertEqual(len(self.repo.get_contents("doc/ReferenceOfClasses.md").content), 38121)
++        self.assertEqual(len(self.repo.get_contents("/doc/ReferenceOfClasses.md").content), 38121)
+ 
+     def testGetContentsWithRef(self):
+         self.assertEqual(len(self.repo.get_readme(ref="refs/heads/topic/ExperimentOnDocumentation").content), 6747)
+-        self.assertEqual(len(self.repo.get_contents("doc/ReferenceOfClasses.md", ref="refs/heads/topic/ExperimentOnDocumentation").content), 43929)
++        self.assertEqual(len(self.repo.get_contents("/doc/ReferenceOfClasses.md", ref="refs/heads/topic/ExperimentOnDocumentation").content), 43929)
++
++    def testCreateFile(self):
++        newFile = '/doc/testCreateUpdateDeleteFile.md'
++        content = 'Hello world'
++        self.repo.create_file(
++            path=newFile, message='Create file for testCreateFile', content=content,
++            branch="master", committer=github.InputGitAuthor("Enix Yu", "enix223@163.com", "2016-01-15T16:13:30+12:00"),
++            author=github.InputGitAuthor("Enix Yu", "enix223@163.com", "2016-01-15T16:13:30+12:00"))
++
++    def testUpdateFile(self):
++        updateFile = '/doc/testCreateUpdateDeleteFile.md'
++        content = 'Hello World'
++        sha = self.repo.get_contents(updateFile).sha
++        self.repo.update_file(
++            path=updateFile, message='Update file for testUpdateFile', content=content, sha=sha,
++            branch="master", committer=github.InputGitAuthor("Enix Yu", "enix223@163.com", "2016-01-15T16:13:30+12:00"),
++            author=github.InputGitAuthor("Enix Yu", "enix223@163.com", "2016-01-15T16:13:30+12:00"))
++
++    def testDeleteFile(self):
++        deleteFile = '/doc/testCreateUpdateDeleteFile.md'
++        sha = self.repo.get_contents(deleteFile).sha
++        self.repo.delete_file(path=deleteFile, message='Delete file for testDeleteFile', sha=sha, branch="master")
+ 
+     def testGetArchiveLink(self):
+         self.assertEqual(self.repo.get_archive_link("tarball"), "https://nodeload.github.com/jacquev6/PyGithub/tarball/master")

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,9 +8,15 @@ source:
   fn: PyGithub-{{ version }}.tar.gz
   url: https://github.com/PyGithub/PyGithub/archive/v{{ version }}.tar.gz
   sha256: 862f481d5a51825f1f7abc76d3a17e571f378d6b95c629c581f7eccd3ea04200
+  patches:
+    # Adds a patch that provides the ability to create and modify repo content.
+    # Link to the pull request is shown below.
+    #
+    # ( https://github.com/PyGithub/PyGithub/pull/379 )
+    - PR_379.diff
 
 build:
-  number: 0
+  number: 1
   script: python setup.py install --single-version-externally-managed --record=record.txt
 
 requirements:


### PR DESCRIPTION
This applies a very useful PR ( https://github.com/PyGithub/PyGithub/pull/379 ) as a patch to allow one to modify repo content via the GitHub API. In addition to being very useful of its own merits, this patch is essential for getting our own status page up and working ( https://github.com/conda-forge/conda-forge.github.io/issues/78 ). Particularly, it is needed to package our dependencies ( https://github.com/conda-forge/staged-recipes/pull/775 ).
