### PR TITLE
Fix license

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ About pygithub
 
 Home: http://pygithub.github.io/PyGithub/v1/
 
-Package license: GPL-3.0
+Package license: LGPL-3.0
 
 Feedstock license: BSD 3-Clause
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ test:
 
 about:
   home: http://pygithub.github.io/PyGithub/v1/
-  license: GPL-3.0
+  license: LGPL-3.0
   summary: Python library implementing the GitHub API v3
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,4 +32,5 @@ about:
 
 extra:
   recipe-maintainers:
+    - jakirkham
     - pelson


### PR DESCRIPTION
It appears the license was accidentally changes in the metadata from LGPL to GPL-3.0. While the version was correct, PyGithub is under LGPL not GPL. This returns it to LGPL.
