### PR TITLE
Release 1.28

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.27.1" %}
+{% set version = "1.28" %}
 
 package:
   name: pygithub
@@ -7,7 +7,7 @@ package:
 source:
   fn: PyGithub-{{ version }}.tar.gz
   url: https://github.com/PyGithub/PyGithub/archive/v{{ version }}.tar.gz
-  sha256: 464a172d547a0429d038a5a75cbdfbcdf99ab756c7742aad875a3db70ccabf3b
+  sha256: 44feab87eefcdf311fe4ad9c356c279b56ba0fc4dd90baeaec1a52e9875cad76
 
 build:
   number: 0


### PR DESCRIPTION
``` rst
Version 1.28 (September 09, 2016)
-----------------------------------

* test against python 3.5 (5d35284)
* sort params and make them work on py3 (78374b9)
* adds a nicer __repr__ (8571d87)
* Add missing space (464259d)
* Properly handle HTTP Proxy authentication with Python 3 (d015154)
* Fix small typo (987bca0)
* push to 'origin' instead of 'github' (d640666)
```
