### PR TITLE
Release 1.29

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.28" %}
+{% set version = "1.29" %}
 
 package:
   name: pygithub
@@ -7,7 +7,7 @@ package:
 source:
   fn: PyGithub-{{ version }}.tar.gz
   url: https://github.com/PyGithub/PyGithub/archive/v{{ version }}.tar.gz
-  sha256: 44feab87eefcdf311fe4ad9c356c279b56ba0fc4dd90baeaec1a52e9875cad76
+  sha256: bee9760003739bc80d0f970067eb3c6188343bbeed3f497e9adf04d9c703274c
 
 build:
   number: 0


### PR DESCRIPTION
``` rst
Version 1.29 (October 10, 2016)
-----------------------------------

* add issue assignee param (3a8edc7)
* Fix diffrerent case (fcf6cfb)
* DOC: remove easy_install suggestion; update links (45e76d9)
* Add permission param documentation (9347345)
* Add ability to set permission for team repo (5dddea7)
* Fix status check (073bb44)
* adds support for content dirs (0799753)
```
