### PR TITLE
BF: limit pyjwt to <2.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
@@ -22,7 +22,7 @@ requirements:
 
   run:
     - python >=3
-    - pyjwt
+    - pyjwt <2.0
     - requests >=2.14.0,<2.25
     - deprecated
 


### PR DESCRIPTION
Otherwise it leads to installation of a more recent version, whenever upstream
explicitly requires lower one
https://github.com/PyGithub/PyGithub/blob/master/setup.py#L101
and that leads to distuils to puke upon import, e.g. as in this case:
https://github.com/conda-forge/datalad-container-feedstock/issues/7

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
